### PR TITLE
Fix chart axes

### DIFF
--- a/apps/block_scout_web/assets/js/lib/history_chart.js
+++ b/apps/block_scout_web/assets/js/lib/history_chart.js
@@ -89,7 +89,7 @@ const config = {
         grid,
         ticks: {
           beginAtZero: true,
-          callback: (value, _index, _values) => `$${numeral(value).format('0,0.00')}`,
+          callback: (value, _index, _values) => `$${numeral(value).format('0,0.0000')}`,
           maxTicksLimit: 4,
           color: sassVariables.dashboardBannerChartAxisFontColor
         }
@@ -98,7 +98,7 @@ const config = {
         position: 'right',
         grid,
         ticks: {
-          callback: (_value, _index, _values) => '',
+          callback: (_value, _index, _values) => `$${numeral(_value).format('0,0')}`,
           maxTicksLimit: 6,
           drawOnChartArea: false,
           color: sassVariables.dashboardBannerChartAxisFontColor

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_footer.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_footer.html.eex
@@ -27,7 +27,7 @@
           <a href="https://www.twitter.com/electroneum/" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Twitter") %>'>
             <div class="footer-social-icon-container fontawesome-icon twitter"></div>
           </a>
-          <a href="https://t.me/joinchat/DxoSakHOdk5mqsE-LelfVg" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Telegram") %>'>
+          <a href="https://t.me/officialelectroneum" rel="noreferrer" target="_blank" class="footer-social-icon" title='<%= gettext("Telegram") %>'>
             <div class="footer-social-icon-container fontawesome-icon telegram"></div>
           </a>
         </div>


### PR DESCRIPTION
NB the panel of data below the chart alternatively fetches it's data from the CMC API, which requires an API key, hence the zero readings on a privately ran explorer. I will update the env file in the production servers for official test, stage & mainnet servers with the API key.
